### PR TITLE
[DO NOT MERGE] updating the bob version in preps for next week

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   version:
     description: Version of bob CLI to install
     required: false
-    default: '0.0.22'
+    default: '0.0.24'
 runs:
   using: node16
   main: dist/index.js

--- a/bob.js
+++ b/bob.js
@@ -5,7 +5,7 @@ const githubRelease = require('./github-release');
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.0.22';
+const latestVersion = '0.0.24';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/dist/index.js
+++ b/dist/index.js
@@ -69,7 +69,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.0.22';
+const latestVersion = '0.0.24';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);


### PR DESCRIPTION
Only merge this in when `v0.0.24` version of `bob` has been cut. Track by following this [PR](https://github.com/hashicorp/bob/pull/70) 