### PR TITLE
Bump bob default version to 0.0.29

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   version:
     description: Version of bob CLI to install
     required: false
-    default: '0.0.27'
+    default: '0.0.29'
 runs:
   using: node16
   main: dist/index.js

--- a/bob.js
+++ b/bob.js
@@ -5,7 +5,7 @@ const githubRelease = require('./github-release');
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.0.27';
+const latestVersion = '0.0.29';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/dist/index.js
+++ b/dist/index.js
@@ -69,7 +69,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.0.27';
+const latestVersion = '0.0.29';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);


### PR DESCRIPTION
Just followed Claire's previous PR here: https://github.com/hashicorp/action-setup-bob/pull/6