### PR TITLE
bump bob version to 0.1.10

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: Version of bob CLI to install
     required: false
-    default: '0.1.9'
+    default: '0.1.10'
 runs:
   using: node16
   main: dist/index.js

--- a/bob.js
+++ b/bob.js
@@ -10,7 +10,7 @@ const githubRelease = require('./github-release');
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.1.9';
+const latestVersion = '0.1.10';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/dist/index.js
+++ b/dist/index.js
@@ -79,7 +79,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.1.9';
+const latestVersion = '0.1.10';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);


### PR DESCRIPTION
bumping bob version in preparation for the new bob release -- (with these new changes: https://github.com/hashicorp/bob/pull/123)