### PR TITLE
bump bob version to 0.1.13

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: Version of bob CLI to install
     required: false
-    default: '0.1.12'
+    default: '0.1.13'
 runs:
   using: node16
   main: dist/index.js

--- a/bob.js
+++ b/bob.js
@@ -10,7 +10,7 @@ const githubRelease = require('./github-release');
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.1.12';
+const latestVersion = '0.1.13';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);

--- a/dist/index.js
+++ b/dist/index.js
@@ -79,7 +79,7 @@ const githubRelease = __nccwpck_require__(3098);
 const executableName = 'bob';
 const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'bob';
-const latestVersion = '0.1.12';
+const latestVersion = '0.1.13';
 
 async function downloadReleaseAsset(client, releaseAsset, directory) {
   return await githubRelease.downloadAsset(client, gitHubRepositoryOwner, gitHubRepositoryRepo, releaseAsset, directory);


### PR DESCRIPTION
bump to `0.1.13` for the version in preps for the bob release to include the fix in this bob PR: https://github.com/hashicorp/bob/pull/161