### PR TITLE
Don't leave cruft in $PWD when installing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,33 @@ jobs:
         run_quiet apt install --yes gh
         gh --version
 
+    # Create a marker we can use later to verify no files were added to the working directory.
+    # Extra files make goreleaser anxious.
+    - name: Create Marker File
+      env:
+        CRUFT_MARKER: "${{ runner.temp }}/pre-install-marker"
+      run: touch "${CRUFT_MARKER}"
+
     - name: Install bob
       uses: ./
       id: install
       with:
         tag: ${{ matrix.tag }}
         github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+
+    # Find anything in the working directory newer than the marker created above
+    - name: Check For New Files
+      env:
+        CRUFT_LOG: "${{ runner.temp }}/bob-installer-cruft.txt"
+        CRUFT_MARKER: "${{ runner.temp }}/pre-install-marker"
+      run: |
+        find "$PWD" -newer "${CRUFT_MARKER}" > "${CRUFT_LOG}"
+        if [ "$(wc -l < "${{ env.CRUFT_LOG }}" | xargs)" -gt 0 ]; then
+          echo "::error::Unexpected changes to working directory (tree):"
+          cat "${CRUFT_LOG}"
+          exit 1
+        fi
+        echo "No unexpected files found."
 
     - name: Test reported version
       env:

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,4 @@ runs:
       id: capture
       shell: bash
       run: |
-        bob -version | tee .version_check
-        echo "installed_version=$(< .version_check)" >> "$GITHUB_OUTPUT"
+        echo "installed_version=$(bob -version)" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
I broke this when refactoring the action.  It reports the version installed, but also leaves a file in $PWD, which causes goreleaser to get [angsty](https://github.com/hashicorp/releases-api/actions/runs/10498182059/job/29083182345#step:10:62) and not ship products.

The code change still produces the version as an action output, but no intermediate file is created.

The CI workflow is updated to test that no new files are added beneath the working directory when running the action.