### PR TITLE
update action-install-gh-release for newer node.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Fetch release artifact
-      uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
+      uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
       with:
         repo: hashicorp/bob
         tag: ${{ inputs.tag }}


### PR DESCRIPTION
Howdy! This cropped up in a nomad-releases workflow that uses this action-setup-bob composite action.

Node.js 20 actions are deprecated, producing warnings in workflow runs.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This includes jaxxstorm/action-install-gh-release@v1.12.0, but v3.0.0 updates the node version:
- https://github.com/jaxxstorm/action-install-gh-release/releases/tag/v3.0.0

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
